### PR TITLE
Arreglos en IRCTask

### DIFF
--- a/IRCTask.vb
+++ b/IRCTask.vb
@@ -37,11 +37,16 @@ Public Class IRCTask
         Thread = New Threading.Thread(New Threading.ParameterizedThreadStart(Sub()
 
                                                                                  Do
-                                                                                     For Each s As String In _nFunc.Invoke
-                                                                                         If Not String.IsNullOrEmpty(s) Then
-                                                                                             _client.SendText(s)
-                                                                                         End If
-                                                                                     Next
+                                                                                     Try
+                                                                                         For Each s As String In _nFunc.Invoke
+                                                                                             If Not String.IsNullOrEmpty(s) Then
+                                                                                                 _client.SendText(s)
+                                                                                             End If
+                                                                                         Next
+                                                                                     Catch ex As Exception
+                                                                                         Debug_Log("TASK EX: " & ex.Message, "THREAD", BOTName)
+                                                                                     End Try
+
                                                                                      If Not _infinite Then
                                                                                          Exit Do
                                                                                      End If

--- a/IRC_Client.vb
+++ b/IRC_Client.vb
@@ -123,20 +123,20 @@ Public Class IRC_Client
                     CheckUsersIRCTask.Run()
 
 
-                    Dim UpdateExtractFunc As New Func(Of String())(Function()
-                                                                       Mainwikibot.UpdatePageExtracts(True)
-                                                                       Return {""}
-                                                                   End Function)
-                    Dim UpdateExtractTask As New IRCTask(Me, 43200000, True, UpdateExtractFunc)
+                Dim UpdateExtractFunc As New Func(Of String())(Function()
+                                                                   Mainwikibot.UpdatePageExtracts(True)
+                                                                   Return {""}
+                                                               End Function)
+                Dim UpdateExtractTask As New IRCTask(Me, 43200000, True, UpdateExtractFunc)
                     UpdateExtractTask.Run()
 
 
-                    Dim ArchiveAllFunc As New Func(Of String())(Function()
-                                                                    Mainwikibot.ArchiveAllInclusions(True)
-                                                                    Return {""}
-                                                                End Function)
-                    Dim ArchiveAllTask As New IRCTask(Me, 43200000, True, ArchiveAllFunc)
-                    ArchiveAllTask.Run()
+                Dim ArchiveAllFunc As New Func(Of String())(Function()
+                                                                Mainwikibot.ArchiveAllInclusions(True)
+                                                                Return {""}
+                                                            End Function)
+                Dim ArchiveAllTask As New IRCTask(Me, 43200000, True, ArchiveAllFunc)
+                ArchiveAllTask.Run()
 
 
 
@@ -151,11 +151,11 @@ Public Class IRC_Client
                                            Console.WriteLine(DateTime.Now.ToString("yyyy/MM/dd HH:mm:ss") & " | " & sCommand)
 
                                            Dim CommandFunc As New Func(Of String())(Function()
-                                                                                            Return {Command.ResolveCommand(sCommand, HasExited, _sNickName)}
-                                                                                        End Function)
+                                                                                        Return {Command.ResolveCommand(sCommand, HasExited, _sNickName)}
+                                                                                    End Function)
                                            Dim IRCResponseTask As New IRCTask(Me, 0, False, CommandFunc)
+                                           Debug_Log("Run irc response", "LOCAL", BOTName)
                                            IRCResponseTask.Run()
-
 
 
                                            If Not _tcpclientConnection.Connected Then
@@ -180,7 +180,10 @@ Public Class IRC_Client
                                    Catch OtherEx As Exception
                                        Log("IRC: Error Connecting: " + OtherEx.Message, "IRC", _sNickName)
                                    End Try
+
+
                                End Sub)
+
 
             Catch ex As SocketException
 


### PR DESCRIPTION
Se capturan posible excepciones en threads que en linux (bajo mono) provoca que la aplicacion completa sea descartada.